### PR TITLE
Add option to use 'vertical+horizontal' knobs

### DIFF
--- a/apps/docs/e2e/index.spec.ts
+++ b/apps/docs/e2e/index.spec.ts
@@ -252,3 +252,57 @@ test.describe('"Horizontal orientation" example', () => {
     });
   });
 });
+
+
+test.describe('"Vertical and horizontal orientation" example', () => {
+  let container: Locator;
+
+  test.beforeEach(({page}) => {
+    container = locators.exampleContainer({
+      page,
+      name: 'Vertical and horizontal orientation',
+    });
+  });
+
+  test('has "View source" link leading to "KnobPercentageVerticalHorizontal.tsx" source code file', async ({
+    page,
+  }) => {
+    const viewSourceLink = locators.exampleViewSourceLink({container});
+    await expects.sourceCodeLinkIsValid({
+      link: viewSourceLink,
+      page,
+      filePath: 'apps/docs/src/components/knobs/KnobPercentageVerticalHorizontal.tsx',
+    });
+  });
+
+  test.describe('"Y+X" knob', () => {
+    let knob: Locator;
+    let knobOutput: Locator;
+
+    test.beforeEach(() => {
+      knob = locators.exampleKnob({container, name: 'Y+X'});
+      knobOutput = locators.exampleKnobOutput({container});
+    });
+
+    test('has correct default value', async () => {
+      await expects.knobValueIsEqualTo({knob, valueNow: 50});
+      await expects.knobValueTextIs({knob, knobOutput, valueText: '50%'});
+    });
+
+    test('has correct drag up behaviour', async ({page}) => {
+      await expects.knobDragsUpCorrectly({knob, valueNow: 50, page});
+    });
+
+    test('has correct drag down behaviour', async ({page}) => {
+      await expects.knobDragsDownCorrectly({knob, valueNow: 50, page});
+    });
+
+    test('has correct drag left behaviour', async ({page}) => {
+      await expects.knobDragsLeftCorrectly({knob, valueNow: 50, page});
+    });
+
+    test('has correct drag right behaviour', async ({page}) => {
+      await expects.knobDragsRightCorrectly({knob, valueNow: 50, page});
+    });
+  });
+});

--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -3,6 +3,7 @@ import {KnobDecorative} from '@/components/knobs/KnobDecorative';
 import {KnobFrequency} from '@/components/knobs/KnobFrequency';
 import {KnobPercentage} from '@/components/knobs/KnobPercentage';
 import {KnobPercentageHorizontal} from '@/components/knobs/KnobPercentageHorizontal';
+import {KnobPercentageVerticalHorizontal} from '@/components/knobs/KnobPercentageVerticalHorizontal';
 import {ExternalLinkUnstyled} from '@/components/ui/ExternalLinkUnstyled';
 import {TableApi} from '@/components/ui/TableApi';
 
@@ -95,6 +96,13 @@ function IndexPage() {
           >
             <KnobPercentageHorizontal label='X' theme='stone' />
           </Example>
+          <Example
+            title='Vertical and horizontal orientation'
+            description="The knob gesture can occur along both the vertical (Y) axis and the horizontal (X) axis."
+            source='https://github.com/satelllte/react-knob-headless/blob/main/apps/docs/src/components/knobs/KnobPercentageVerticalHorizontal.tsx'
+          >
+            <KnobPercentageVerticalHorizontal label='Y+X' theme='pink' />
+          </Example>
         </div>
       </Section>
       <Section title='Gotchas'>
@@ -156,7 +164,7 @@ function IndexPage() {
                 type: 'union',
                 defaultValue: 'vertical',
                 description:
-                  'Orientation of the knob and its gesture. Can be "vertical" or "horizontal".',
+                  'Orientation of the knob and its gesture. Can be "vertical", "horizontal", or "vertical-horizontal".',
               },
               {
                 name: 'includeIntoTabOrder',

--- a/apps/docs/src/components/knobs/KnobPercentageVerticalHorizontal.tsx
+++ b/apps/docs/src/components/knobs/KnobPercentageVerticalHorizontal.tsx
@@ -1,0 +1,9 @@
+'use client';
+import {KnobPercentage} from './KnobPercentage';
+
+type KnobPercentageProps = React.ComponentProps<typeof KnobPercentage>;
+type KnobPercentageVerticalHorizontalProps = Omit<KnobPercentageProps, 'orientation'>;
+
+export function KnobPercentageVerticalHorizontal(props: KnobPercentageVerticalHorizontalProps) {
+  return <KnobPercentage orientation='vertical-horizontal' {...props} />;
+}

--- a/packages/react-knob-headless/src/KnobHeadless.test.tsx
+++ b/packages/react-knob-headless/src/KnobHeadless.test.tsx
@@ -137,6 +137,31 @@ describe('KnobHeadless', () => {
     `);
   });
 
+  it('sets "aria-orientation" to "vertical", when "orientation" is "vertical-horizontal"', () => {
+    render(
+      <KnobHeadless
+        {...props}
+        orientation='vertical-horizontal'
+        aria-label='Test Knob'
+      />,
+    );
+
+    const knob = screen.getByRole('slider', {name: 'Test Knob'});
+
+    expect(knob).toMatchInlineSnapshot(`
+      <div
+        aria-label="Test Knob"
+        aria-orientation="vertical"
+        aria-valuemax="5"
+        aria-valuemin="-5"
+        aria-valuenow="2"
+        aria-valuetext="2 units"
+        role="slider"
+        tabindex="-1"
+      />
+    `);
+  });
+
   it('sets tabIndex to 0, when "includeIntoTabOrder" is true', () => {
     render(
       <KnobHeadless {...props} includeIntoTabOrder aria-label='Test Knob' />,

--- a/packages/react-knob-headless/src/KnobHeadless.tsx
+++ b/packages/react-knob-headless/src/KnobHeadless.tsx
@@ -69,7 +69,7 @@ type KnobHeadlessProps = NativeDivPropsToExtend &
      * Orientation of the knob and its gesture.
      * Default: "vertical".
      */
-    readonly orientation?: 'horizontal' | 'vertical';
+    readonly orientation?: 'horizontal' | 'vertical' | 'vertical-horizontal';
     /**
      * Whether to include the element into the sequential tab order.
      * If true, the element will be focusable via the keyboard by tabbing.
@@ -111,10 +111,9 @@ export const KnobHeadless = forwardRef<HTMLDivElement, KnobHeadlessProps>(
     /* v8 ignore start */ // eslint-disable-line capitalized-comments
     const bindDrag = useDrag(
       ({delta}) => {
-        const diff01 =
-          orientation === 'horizontal'
-            ? delta[0] * dragSensitivity
-            : delta[1] * -dragSensitivity; // Negating the sensitivity for vertical axis (Y), since the direction of it goes top down on computer screens.
+        let diff01 = 0;
+        if (orientation.includes('horizontal')) diff01 += delta[0] * dragSensitivity;
+        if (orientation.includes('vertical')) diff01 += delta[1] * -dragSensitivity; // Negating the sensitivity for vertical axis (Y), since the direction of it goes top down on computer screens.
 
         // Conversion of the raw value to 0-1 range
         // makes the sensitivity to be independent from min-max values range,
@@ -146,7 +145,7 @@ export const KnobHeadless = forwardRef<HTMLDivElement, KnobHeadlessProps>(
         aria-valuenow={value}
         aria-valuemin={valueMin}
         aria-valuemax={valueMax}
-        aria-orientation={orientation}
+        aria-orientation={orientation === 'vertical-horizontal' ? 'vertical' : orientation}
         aria-valuetext={valueRawDisplayFn(valueRaw)}
         tabIndex={includeIntoTabOrder ? 0 : -1}
         {...mergeProps(


### PR DESCRIPTION
Closes #66.
I set `aria-orientation` to `vertical` with knobs that can be dragged both vertically and horizontally because vertical is the default for audio applications.
Note that keyboard users could already move any type of knob with all arrow keys (up/down and left/right) independently of the orientation of the knob. This new option brings that same feature to mouse users.